### PR TITLE
Correct BlogPost type for published date

### DIFF
--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -30,10 +30,16 @@ export interface BlogPost {
   title: string;
   slug: string;
   description: string;
-  date: string;
+  /**
+   * Publication date for the post. Matches the `published` field
+   * defined in the content collection schema and is stored as a
+   * JavaScript Date instance by Astro.
+   */
+  published: Date;
+  category: string;
   tags: string[];
   featured?: boolean;
-  published?: boolean;
+  draft?: boolean;
   readingTime?: number;
   image?: string;
 }


### PR DESCRIPTION
## Summary
- fix `BlogPost` interface: published is a Date, add category/draft fields and comment

## Testing
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_6898e552e4f8832bb741eaa1282aeb09