### PR TITLE
fix: prevent duplicate header listeners

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -185,49 +185,64 @@ const displayTitle = customTitle || "Alan Ye";
         ticking = false;
     }
 
-    function handleScroll() {
+    const scrollHandler = () => {
         const scrollY = window.scrollY;
         const scrollDelta = Math.abs(scrollY - lastScrollY);
-        
+
         if (scrollDelta > 10 || !ticking) {
             if (scrollDelta > 10) {
                 updateHeader();
-            } else {
-                if (!ticking) {
-                    requestAnimationFrame(updateHeader);
-                    ticking = true;
-                }
+            } else if (!ticking) {
+                requestAnimationFrame(updateHeader);
+                ticking = true;
             }
         }
+    };
+
+    const logoMouseEnterHandler = () => {
+        const currentScale = parseFloat(
+            getComputedStyle(document.documentElement)
+                .getPropertyValue('--logo-scale') || '1'
+        );
+
+        const hoverScale = currentScale * 1.05;
+        document.documentElement.style.setProperty('--logo-scale', hoverScale.toString());
+        document.documentElement.style.setProperty('--logo-width', '110');
+    };
+
+    const logoMouseLeaveHandler = () => {
+        updateHeader();
+        document.documentElement.style.setProperty('--logo-width', '100');
+    };
+
+    let logoDesktop: HTMLElement | null = null;
+    let logoMobile: HTMLElement | null = null;
+
+    function cleanupHeader() {
+        window.removeEventListener('scroll', scrollHandler);
+
+        [logoDesktop, logoMobile].forEach(logo => {
+            if (logo) {
+                logo.removeEventListener('mouseenter', logoMouseEnterHandler);
+                logo.removeEventListener('mouseleave', logoMouseLeaveHandler);
+            }
+        });
     }
 
     function initializeHeader() {
-        window.addEventListener('scroll', handleScroll, { passive: true });
-        
+        cleanupHeader();
+
+        window.addEventListener('scroll', scrollHandler, { passive: true });
+
         updateHeader();
 
-        const logoDesktop = document.getElementById('site-logo-desktop');
-        const logoMobile = document.getElementById('site-logo-mobile');
-        
+        logoDesktop = document.getElementById('site-logo-desktop');
+        logoMobile = document.getElementById('site-logo-mobile');
+
         [logoDesktop, logoMobile].forEach(logo => {
             if (logo) {
-                logo.addEventListener('mouseenter', () => {
-                    const currentScale = parseFloat(
-                        getComputedStyle(document.documentElement)
-                            .getPropertyValue('--logo-scale') || '1'
-                    );
-                    
-                    const hoverScale = currentScale * 1.05;
-                    document.documentElement.style.setProperty('--logo-scale', hoverScale.toString());
-                    
-                    document.documentElement.style.setProperty('--logo-width', '110');
-                });
-                
-                logo.addEventListener('mouseleave', () => {
-                    updateHeader();
-                    
-                    document.documentElement.style.setProperty('--logo-width', '100');
-                });
+                logo.addEventListener('mouseenter', logoMouseEnterHandler);
+                logo.addEventListener('mouseleave', logoMouseLeaveHandler);
             }
         });
     }
@@ -239,6 +254,7 @@ const displayTitle = customTitle || "Alan Ye";
     }
 
     document.addEventListener('astro:page-load', () => {
+        cleanupHeader();
         setTimeout(() => {
             initializeHeader();
             updateHeader();


### PR DESCRIPTION
## Summary
- clean up existing header listeners before reinitializing
- store header event handler references and expose cleanup

## Testing
- `pnpm astro check` *(fails: Property 'style' does not exist on type 'Element')*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68be527d39b4832b95ed2299d6ad32b5