### PR TITLE
fix: avoid duplicate listeners on navigation

### DIFF
--- a/src/components/Main.astro
+++ b/src/components/Main.astro
@@ -274,30 +274,12 @@ const recentPosts = await getCollection("posts", ({ data }) => {
         }, 150);
     }
 
-    function initialize() {
-        cacheElements();
-        updateSectionHeadings();
-
-        window.addEventListener("scroll", handleSectionScroll, {
-            passive: true,
-        });
-        window.addEventListener("resize", handleResize, { passive: true });
-    }
-
-    if (document.readyState === "loading") {
-        document.addEventListener("DOMContentLoaded", initialize);
-    } else {
-        initialize();
-    }
-
-    document.addEventListener("astro:page-load", () => {
-        setTimeout(() => {
-            initialize();
-        }, 100);
-    });
+    let listenersAttached = false;
+    let emailLink: HTMLElement | null = null;
+    let emailClickHandler: ((e: MouseEvent) => void) | null = null;
 
     function setupEmailProtection() {
-        const emailLink = document.getElementById("email-link");
+        emailLink = document.getElementById("email-link");
 
         if (emailLink) {
             const user = "hcaer"; // 'reach' reversed
@@ -307,21 +289,54 @@ const recentPosts = await getCollection("posts", ({ data }) => {
                 "@" +
                 domain.split("").reverse().join("");
 
-            emailLink.addEventListener("click", function (e) {
+            emailClickHandler = function (e) {
                 e.preventDefault();
                 window.location.href = "mailto:" + actualEmail;
-            });
+            };
+
+            emailLink.addEventListener("click", emailClickHandler);
         }
     }
 
-    if (document.readyState === "loading") {
-        document.addEventListener("DOMContentLoaded", setupEmailProtection);
-    } else {
+    function initialize() {
+        if (listenersAttached) return;
+
+        cacheElements();
+        updateSectionHeadings();
+
+        window.addEventListener("scroll", handleSectionScroll, {
+            passive: true,
+        });
+        window.addEventListener("resize", handleResize, { passive: true });
+
         setupEmailProtection();
+        listenersAttached = true;
+    }
+
+    function cleanup() {
+        if (!listenersAttached) return;
+
+        window.removeEventListener("scroll", handleSectionScroll);
+        window.removeEventListener("resize", handleResize);
+
+        if (emailLink && emailClickHandler) {
+            emailLink.removeEventListener("click", emailClickHandler);
+        }
+
+        emailLink = null;
+        emailClickHandler = null;
+        listenersAttached = false;
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", initialize);
+    } else {
+        initialize();
     }
 
     document.addEventListener("astro:page-load", () => {
-        setTimeout(setupEmailProtection, 100);
+        cleanup();
+        setTimeout(initialize, 100);
     });
 </script>
 

--- a/src/pages/friends.astro
+++ b/src/pages/friends.astro
@@ -208,7 +208,9 @@ const pageDescription = "Place where I list the talented people I know.";
       const timing = 'cubic-bezier(0.23, 1, 0.32, 1)';
       const maxDelay = prefersReduced ? 0 : 80;
 
-      const cards = Array.from(grid.querySelectorAll('.friend-card'));
+      const cards = Array.from(
+        grid.querySelectorAll('.friend-card'),
+      ) as HTMLElement[];
       if (cards.length === 0) return;
 
       grid.classList.add('is-shuffling');


### PR DESCRIPTION
## Summary
- prevent duplicate scroll/resize/email listeners by tracking initialization and providing cleanup
- remove listeners before reinitializing on `astro:page-load`
- cast friend-card NodeList to `HTMLElement[]` for type safety

## Testing
- `pnpm astro check`
- `pnpm build`
- `node` script confirming listener counts remain constant

------
https://chatgpt.com/codex/tasks/task_e_68be52bcd344832b9982f790e067b6a0