### PR TITLE
fix: remove blog posts section from home page

### DIFF
--- a/src/components/Main.astro
+++ b/src/components/Main.astro
@@ -5,7 +5,6 @@ import ProjectCard from "./ui/ProjectCard.astro";
 import ExperienceItem from "./ui/ExperienceItem.astro";
 import SkillsGroup from "./ui/SkillsGroup.astro";
 import ExternalLink from "./ui/ExternalLink.astro";
-import PostListItem from "./PostListItem.astro";
 import SiteFooter from "./ui/SiteFooter.astro";
 
 import {
@@ -17,20 +16,6 @@ import {
     aboutContent,
     contactContent,
 } from "../data/content";
-
-import { getCollection } from "astro:content";
-
-const recentPosts = await getCollection("posts", ({ data }) => {
-    return !data.draft;
-}).then((posts) =>
-    posts
-        .sort(
-            (a, b) =>
-                new Date(b.data.published).getTime() -
-                new Date(a.data.published).getTime(),
-        )
-        .slice(0, 3),
-);
 ---
 
 <div class="min-h-screen bg-white dark:bg-slate-900">
@@ -56,47 +41,6 @@ const recentPosts = await getCollection("posts", ({ data }) => {
                 </div>
             </ContentSection>
 
-            
-            <div
-                class="content-section border-l-2 border-slate-200 pl-6 md:pl-8"
-                id="blog"
-            >
-                <h2
-                    class="section-heading text-2xl md:text-3xl lg:text-4xl text-slate-900 mb-4 md:mb-6 tracking-wide"
-                >
-                    <a
-                        href="/archive"
-                        class="hover:text-slate-600 transition-colors no-underline inline-block"
-                    >
-                        Recent Posts
-                    </a>
-                </h2>
-                <div class="space-y-6">
-                    {
-                        recentPosts.map((post) => (
-                            <PostListItem
-                                title={post.data.title}
-                                description={post.data.description}
-                                slug={post.slug}
-                                published={post.data.published}
-                                size="small"
-                            />
-                        ))
-                    }
-
-                    
-            <div class="pt-4">
-              <a
-                href="/archive"
-                class="inline-flex items-center text-slate-900 hover:text-slate-600 transition-colors text-sm"
-              >
-                View all posts →
-              </a>
-            </div>
-                </div>
-            </div>
-
-            
             <ContentSection title="Skills" id="skills">
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                     {
@@ -357,8 +301,4 @@ const recentPosts = await getCollection("posts", ({ data }) => {
 
     .body-text { @apply dark:text-slate-300; }
     .content-section :global(a) { @apply dark:text-slate-100 dark:hover:text-slate-300; }
-    #blog :global(.post-item a:focus-visible) {
-        text-decoration-thickness: 1.5px !important;
-        text-underline-offset: 3px !important;
-    }
 </style>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The home page (`Main.astro`, used only by `index.astro`) no longer shows the "Recent Posts" block, post previews, or links to `/archive`. Archive routes, individual posts, RSS, and OG routes are unchanged.

## Testing

- `bun run check`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76de2412-8bf5-412a-b319-418183e85f73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76de2412-8bf5-412a-b319-418183e85f73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

